### PR TITLE
set a constant for bmp pointer computation to avoid keccak

### DIFF
--- a/__snapshots__/Bit.test.js
+++ b/__snapshots__/Bit.test.js
@@ -1,1 +1,1 @@
-exports['Bit useBit() gas cost 1'] = 44097
+exports['Bit useBit() gas cost 1'] = 44034

--- a/__snapshots__/CancelVerifier.test.js
+++ b/__snapshots__/CancelVerifier.test.js
@@ -1,1 +1,1 @@
-exports['CancelVerifier gas cost 1'] = 52405
+exports['CancelVerifier gas cost 1'] = 52346

--- a/__snapshots__/LimitSwapVerifier.test.js
+++ b/__snapshots__/LimitSwapVerifier.test.js
@@ -1,5 +1,5 @@
-exports['LimitSwapVerifier tokenToToken() gas cost 1'] = 130986
+exports['LimitSwapVerifier tokenToToken() gas cost 1'] = 130929
 
-exports['LimitSwapVerifier ethToToken() gas cost 1'] = 113251
+exports['LimitSwapVerifier ethToToken() gas cost 1'] = 113195
 
-exports['LimitSwapVerifier tokenToEth gas cost 1'] = 105458
+exports['LimitSwapVerifier tokenToEth gas cost 1'] = 105402

--- a/__snapshots__/TransferVerifier.test.js
+++ b/__snapshots__/TransferVerifier.test.js
@@ -1,3 +1,3 @@
-exports['TransferVerifier tokenTransfer() gas cost 1'] = 89884
+exports['TransferVerifier tokenTransfer() gas cost 1'] = 89828
 
-exports['TransferVerifier ethTransfer() gas cost 1'] = 68444
+exports['TransferVerifier ethTransfer() gas cost 1'] = 68385

--- a/contracts/Libraries/Bit.sol
+++ b/contracts/Libraries/Bit.sol
@@ -7,6 +7,10 @@ pragma abicoder v1;
 /// @dev Solution adapted from https://github.com/PISAresearch/metamask-comp/blob/77fa8295c168ee0b6bf801cbedab797d6f8cfd5d/src/contracts/BitFlipMetaTransaction/README.md
 /// @dev This is a gas optimized technique that stores up to 256 replay protection bits per bytes32 slot
 library Bit {
+  /// @dev Initial pointer for bitmap storage ptr computation
+  /// @notice This is the uint256 representation of keccak("bmp")
+  uint256 constant INITIAL_BMP_PTR = 
+  48874093989078844336340380824760280705349075126087700760297816282162649029611;
 
   /// @dev Adds a bit to the uint256 bitmap at bitmapIndex
   /// @dev Value of bit cannot be zero and must represent a single bit
@@ -31,7 +35,7 @@ library Bit {
   /// @dev Get a bitmap storage pointer
   /// @return The bytes32 pointer to the storage location of the uint256 bitmap at bitmapIndex
   function bitmapPtr (uint256 bitmapIndex) internal pure returns (bytes32) {
-    return keccak256(abi.encodePacked("bmp", bitmapIndex));
+    return bytes32(INITIAL_BMP_PTR + bitmapIndex);
   }
 
   /// @dev Returns the uint256 value at storage location ptr

--- a/test/CancelVerifier.test.js
+++ b/test/CancelVerifier.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const { ethers } = require('hardhat')
 const brinkUtils = require('@brinkninja/utils')
 const { soliditySha3, padLeft } = require('web3-utils')
-const { encodeFunctionCall } = brinkUtils
+const { BN, encodeFunctionCall } = brinkUtils
 const snapshotGas = require('./helpers/snapshotGas')
 const { setupProxyAccount, getSigners } = require('@brinkninja/core/test/helpers')
 
@@ -26,10 +26,7 @@ describe('CancelVerifier', function() {
       this.cancelVerifier.address,
       encodeFunctionCall('cancel', ['uint256', 'uint256'], [0, 1])
     )
-    const bmpPtr = soliditySha3(
-      { t: 'string', v: 'bmp' },
-      { t: 'uint256', v: 0 }
-    )
+    const bmpPtr = BN(soliditySha3('bmp')).add(BN(0))
     const storedBit = await ethers.provider.getStorageAt(this.proxyAccount.address, bmpPtr)
     expect(storedBit.toString()).to.equal(`0x${padLeft('1', 64)}`)
   })


### PR DESCRIPTION
add bitmapIndex to INITIAL_BMP_PTR to get the pointer, less costly than keccak everytime